### PR TITLE
DTSPO-6371 - add private endpoint provider to service bus module

### DIFF
--- a/application-insights.tf
+++ b/application-insights.tf
@@ -1,6 +1,6 @@
 resource "azurerm_application_insights" "appinsights" {
-  name     = "${var.product}-${var.env}"
-  location = var.location
+  name                = "${var.product}-${var.env}"
+  location            = var.location
   resource_group_name = azurerm_resource_group.rg.name
   application_type    = "web"
 

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -1,11 +1,11 @@
 module "key-vault" {
-  source                  = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
-  name                    = "${var.product}-shared-${var.env}"
-  product                 = var.product
-  env                     = var.env
-  tenant_id               = var.tenant_id
-  object_id               = var.jenkins_AAD_objectId
-  resource_group_name     = azurerm_resource_group.rg.name
+  source              = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
+  name                = "${var.product}-shared-${var.env}"
+  product             = var.product
+  env                 = var.env
+  tenant_id           = var.tenant_id
+  object_id           = var.jenkins_AAD_objectId
+  resource_group_name = azurerm_resource_group.rg.name
   # dcd_group_ethos_v2 group object ID
   product_group_object_id = "414c132d-5160-42b3-bbff-43a2e1daafcf"
   common_tags             = local.common_tags

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,13 @@ provider "azurerm" {
   features {}
 }
 
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+  alias                      = "private-endpoint"
+  subscription_id            = var.aks_subscription_id
+}
+
 locals {
   common_tags = {
     "environment"  = var.env

--- a/servicebus.tf
+++ b/servicebus.tf
@@ -1,4 +1,7 @@
 module "queue-namespace" {
+  providers = {
+    azurerm.private-endpoint = azurerm.private-endpoint
+  }
   source              = "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=master"
   name                = "${var.product}-servicebus-${var.env}"
   location            = var.location
@@ -33,38 +36,38 @@ module "update-case-queue" {
 
 # region connection strings and other shared queue information as Key Vault secrets
 resource "azurerm_key_vault_secret" "create_updates_queue_send_conn_str" {
-  name      = "create-updates-queue-send-connection-string"
-  value     = module.create-updates-queue.primary_send_connection_string
+  name         = "create-updates-queue-send-connection-string"
+  value        = module.create-updates-queue.primary_send_connection_string
   key_vault_id = module.key-vault.key_vault_id
 }
 
 resource "azurerm_key_vault_secret" "create_updates_queue_listen_conn_str" {
-  name      = "create-updates-queue-listen-connection-string"
-  value     = module.create-updates-queue.primary_listen_connection_string
+  name         = "create-updates-queue-listen-connection-string"
+  value        = module.create-updates-queue.primary_listen_connection_string
   key_vault_id = module.key-vault.key_vault_id
 }
 
 resource "azurerm_key_vault_secret" "create_updates_queue_max_delivery_count" {
-  name      = "create-updates-queue-max-delivery-count"
-  value     = var.queue_max_delivery_count
+  name         = "create-updates-queue-max-delivery-count"
+  value        = var.queue_max_delivery_count
   key_vault_id = module.key-vault.key_vault_id
 }
 
 resource "azurerm_key_vault_secret" "update_case_queue_send_conn_str" {
-  name      = "update-case-queue-send-connection-string"
-  value     = module.update-case-queue.primary_send_connection_string
+  name         = "update-case-queue-send-connection-string"
+  value        = module.update-case-queue.primary_send_connection_string
   key_vault_id = module.key-vault.key_vault_id
 }
 
 resource "azurerm_key_vault_secret" "update_case_queue_listen_conn_str" {
-  name      = "update-case-queue-listen-connection-string"
-  value     = module.update-case-queue.primary_listen_connection_string
+  name         = "update-case-queue-listen-connection-string"
+  value        = module.update-case-queue.primary_listen_connection_string
   key_vault_id = module.key-vault.key_vault_id
 }
 
 resource "azurerm_key_vault_secret" "update_case_queue_max_delivery_count" {
-  name      = "update-case-queue-max-delivery-count"
-  value     = var.queue_max_delivery_count
+  name         = "update-case-queue-max-delivery-count"
+  value        = var.queue_max_delivery_count
   key_vault_id = module.key-vault.key_vault_id
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -12,14 +12,14 @@ variable "env" {
 variable "subscription" {
 }
 
-variable "ilbIp"{}
+variable "ilbIp" {}
 
 variable "tenant_id" {
   description = "(Required) The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault. This is usually sourced from environemnt variables and not normally required to be specified."
 }
 
 variable "jenkins_AAD_objectId" {
-  description                 = "(Required) The Azure AD object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies."
+  description = "(Required) The Azure AD object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies."
 }
 
 variable "capacity" {
@@ -51,7 +51,7 @@ variable "appinsights_location" {
 }
 
 variable "application_type" {
-  default = "Web"
+  default     = "Web"
   description = "Type of Application Insights (Web/Other)"
 }
 
@@ -74,3 +74,5 @@ variable "destroy_me" {
   description = "Here be dragons! In the future if this is set to Yes then automation will delete this resource on a schedule. Please set to No unless you know what you are doing"
   default     = "No"
 }
+
+variable "aks_subscription_id" {}


### PR DESCRIPTION
JIRA link (if applicable)
[tools.hmcts.net/jira/browse/DTSPO-6371](https://tools.hmcts.net/jira/browse/DTSPO-6371)

Change description
PlatOps have made some changes to the service bus terraform module, mainly around adding the ability to enable private endpoints. We needed to add a Private Endpoint provider to allow for Private endpoints being deployed to a different Subscription to the Service Bus being created.

This change should have no effect on anything currently deployed, but it will allow you to deploy a Service Bus with a Private Endpoint if you add the correct inputs to the module.

More information on that can be found here: [hmcts/terraform-module-servicebus-namespace#usage](https://github.com/hmcts/terraform-module-servicebus-namespace#usage)

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[x] No